### PR TITLE
fix cropping on mobile

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -75,3 +75,23 @@ footer {
     margin-top: 1em;
     text-align: center;
 }
+
+@media screen and (max-width:720px) {
+    thead {
+        tr {
+            th {
+                writing-mode: vertical-rl;
+                text-orientation: sideways-right;
+                vertical-align: top;
+            }
+        }
+    }
+
+    tbody {
+        th,
+        td {
+            padding: 0.5em 0.2em;
+            font-size: 14px;
+        }
+    }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import VersionRow from '../components/VersionRow.astro';
     <head>
 	<meta charset="utf-8" />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=600px" />
 	<meta name="generator" content={Astro.generator} />
 	<title>Fucking Apple Version Numbers</title>
     </head>


### PR DESCRIPTION
Better rendering on mobile fixes #2. At smaller widths, reduces padding and makes table headers vertical, sets a fixed viewport so you can see the whole page at once (i think better than horizontal scrolling).

<img width="379" alt="image" src="https://github.com/user-attachments/assets/796c04f3-00ac-4134-b546-ca81877889ff">

